### PR TITLE
Update to PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+  - 7.4
+  - 8.0
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <description>The coding standard for PHP_CodeSniffer itself.</description>
+
+    <file>./src</file>
+
+    <rule ref="PSR12" />
+    <rule ref="PSR12.Classes.AnonClassDeclaration.SpaceAfterKeyword">
+        <severity>0</severity>
+    </rule>
+
+    <arg name="extensions" value="php" />
+    <arg name="colors" />
+    <arg value="p"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,30 +8,13 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <logging>
-        <log type="coverage-html"
-             target="./build/coverage/html"
-             charset="UTF-8"
-             highlight="false"
-             lowUpperBound="35"
-             highLowerBound="70"/>
-        <log type="coverage-clover"
-             target="./build/coverage/log/coverage.xml"/>
+        <junit outputFile="junit.xml"/>
     </logging>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">./vendor</directory>
-                <directory suffix=".php">./tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Provider/HubSpot.php
+++ b/src/Provider/HubSpot.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace HelpScout\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\AbstractProvider;
@@ -63,7 +64,7 @@ class HubSpot extends AbstractProvider
 
     /**
      * @param ResponseInterface $response
-     * @param array|string      $data
+     * @param array|string $data
      *
      * @throws IdentityProviderException
      */
@@ -82,7 +83,7 @@ class HubSpot extends AbstractProvider
     /**
      * Generate a minimal user object from a successful user details request.
      *
-     * @param array       $response
+     * @param array $response
      * @param AccessToken $token
      *
      * @return HubSpotResourceOwner

--- a/src/Provider/HubSpotResourceOwner.php
+++ b/src/Provider/HubSpotResourceOwner.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace HelpScout\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;

--- a/tests/src/HubSpotTest.php
+++ b/tests/src/HubSpotTest.php
@@ -1,20 +1,19 @@
 <?php
+
 namespace HelpScout\OAuth2\Client\Test;
 
 use GuzzleHttp\ClientInterface;
 use HelpScout\OAuth2\Client\Provider\HubSpot;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
 class HubSpotTest extends TestCase
 {
-    /**
-     * @var HubSpot
-     */
-    protected $provider;
+    protected HubSpot $provider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->provider = new HubSpot([
             'clientId' => 'mock_client_id',
@@ -57,8 +56,9 @@ class HubSpotTest extends TestCase
         ];
 
         $url = $this->provider->getAuthorizationUrl($options);
+        parse_str(parse_url($url)['query'], $query);
 
-        $this->assertContains(implode('%20', $options['scope']), $url);
+        $this->assertEquals(implode(' ', $options['scope']), $query['scope']);
     }
 
     public function testGetAuthorizationUrl()
@@ -149,12 +149,10 @@ class HubSpotTest extends TestCase
         $this->assertEquals($accessTokenInfo['hub_domain'], $user->getHubSpotDomain());
     }
 
-    /**
-     * @expectedException \League\OAuth2\Client\Provider\Exception\IdentityProviderException
-     */
     public function testExceptionThrownWhenErrorReceived()
     {
-        $status = rand(401,599);
+        $this->expectException(IdentityProviderException::class);
+        $status = rand(401, 599);
         $postResponseMock = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $postResponseMock->method('getBody')->willReturn('{"error": "error_code","error_description": "A human readable error message"}');
         $postResponseMock->method('getHeader')->willReturn(['content-type' => 'json']);


### PR DESCRIPTION
👋 

Would appreciate some eyes on this, I had to disable some stuff from the PHPUnit XML, weirdly --migrate-xml didn't do anything despite complaining about certain properties not being allowed. 

Have tested that the tests run  and pass on PHP8 but nothing more. 
